### PR TITLE
feat: S3와 spring boot 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 	implementation 'com.google.http-client:google-http-client-jackson2:1.40.1'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+	implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.0")
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,6 @@ dependencies {
 	implementation 'com.google.http-client:google-http-client-jackson2:1.40.1'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
-	implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.0")
-	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/BANnerIt/server/api/s3/controller/S3Controller.java
+++ b/src/main/java/com/BANnerIt/server/api/s3/controller/S3Controller.java
@@ -1,0 +1,24 @@
+package com.BANnerIt.server.api.s3.controller;
+
+import com.BANnerIt.server.api.s3.dto.PresignedUrlRequest;
+import com.BANnerIt.server.api.s3.dto.PresignedUrlResponse;
+import com.BANnerIt.server.api.s3.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/presigned-urls")
+public class S3Controller {
+    private final S3Service s3Service;
+
+    @PostMapping
+    public List<PresignedUrlResponse> createPresignedUrls(
+            @RequestBody PresignedUrlRequest request,
+            @RequestParam(defaultValue = "report") String folder
+    ) {
+        return s3Service.generatePresignedUrls(request, folder);
+    }
+}

--- a/src/main/java/com/BANnerIt/server/api/s3/controller/S3Controller.java
+++ b/src/main/java/com/BANnerIt/server/api/s3/controller/S3Controller.java
@@ -15,7 +15,7 @@ public class S3Controller {
     private final S3Service s3Service;
 
     @PostMapping
-    public List<PresignedUrlResponse> createPresignedUrls(
+    public PresignedUrlResponse createPresignedUrls(
             @RequestBody PresignedUrlRequest request,
             @RequestParam(defaultValue = "report") String folder
     ) {

--- a/src/main/java/com/BANnerIt/server/api/s3/domain/Image.java
+++ b/src/main/java/com/BANnerIt/server/api/s3/domain/Image.java
@@ -14,5 +14,4 @@ public class Image {
     private Long imageId;
 
     private String imageKey;
-    private String url;
 }

--- a/src/main/java/com/BANnerIt/server/api/s3/domain/Image.java
+++ b/src/main/java/com/BANnerIt/server/api/s3/domain/Image.java
@@ -1,0 +1,18 @@
+package com.BANnerIt.server.api.s3.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "images")
+public class Image {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long imageId;
+
+    private String imageKey;
+    private String url;
+}

--- a/src/main/java/com/BANnerIt/server/api/s3/dto/PresignedUrlDto.java
+++ b/src/main/java/com/BANnerIt/server/api/s3/dto/PresignedUrlDto.java
@@ -1,0 +1,4 @@
+package com.BANnerIt.server.api.s3.dto;
+
+public record PresignedUrlDto(String key, String url) {
+}

--- a/src/main/java/com/BANnerIt/server/api/s3/dto/PresignedUrlRequest.java
+++ b/src/main/java/com/BANnerIt/server/api/s3/dto/PresignedUrlRequest.java
@@ -1,0 +1,5 @@
+package com.BANnerIt.server.api.s3.dto;
+
+import java.util.List;
+public record PresignedUrlRequest(List<String> files) {
+}

--- a/src/main/java/com/BANnerIt/server/api/s3/dto/PresignedUrlResponse.java
+++ b/src/main/java/com/BANnerIt/server/api/s3/dto/PresignedUrlResponse.java
@@ -1,0 +1,4 @@
+package com.BANnerIt.server.api.s3.dto;
+
+public record PresignedUrlResponse(String key, String url) {
+}

--- a/src/main/java/com/BANnerIt/server/api/s3/dto/PresignedUrlResponse.java
+++ b/src/main/java/com/BANnerIt/server/api/s3/dto/PresignedUrlResponse.java
@@ -1,4 +1,5 @@
 package com.BANnerIt.server.api.s3.dto;
 
-public record PresignedUrlResponse(String key, String url) {
+import java.util.List;
+public record PresignedUrlResponse(List<PresignedUrlDto> key_urls) {
 }

--- a/src/main/java/com/BANnerIt/server/api/s3/repository/ImageRepository.java
+++ b/src/main/java/com/BANnerIt/server/api/s3/repository/ImageRepository.java
@@ -1,0 +1,7 @@
+package com.BANnerIt.server.api.s3.repository;
+
+import com.BANnerIt.server.api.s3.domain.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/com/BANnerIt/server/api/s3/service/S3Service.java
+++ b/src/main/java/com/BANnerIt/server/api/s3/service/S3Service.java
@@ -1,0 +1,55 @@
+package com.BANnerIt.server.api.s3.service;
+
+import com.BANnerIt.server.api.s3.domain.Image;
+import com.BANnerIt.server.api.s3.dto.PresignedUrlRequest;
+import com.BANnerIt.server.api.s3.dto.PresignedUrlResponse;
+import com.BANnerIt.server.api.s3.repository.ImageRepository;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.URL;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    private final AmazonS3 amazonS3;
+    private final ImageRepository imageRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public List<PresignedUrlResponse> generatePresignedUrls(PresignedUrlRequest request, String folder) {
+        List<PresignedUrlResponse> responseList = new ArrayList<>();
+
+        for (String file : request.files()) {
+            String uuid = UUID.randomUUID().toString();
+            String key = folder + "/" + uuid + "." + file;
+
+            Image image = Image.builder()
+                    .imageKey(key)
+                    .build();
+
+            imageRepository.save(image);
+
+            Date expiration = Date.from(Instant.now().plusSeconds(60 * 5)); // 5분 유효
+
+            GeneratePresignedUrlRequest s3UrlRequest = new GeneratePresignedUrlRequest(bucket, key)
+                    .withMethod(com.amazonaws.HttpMethod.PUT)
+                    .withExpiration(expiration);
+
+            URL url = amazonS3.generatePresignedUrl(s3UrlRequest);
+
+            responseList.add(new PresignedUrlResponse(key, url.toString()));
+        }
+
+        return responseList;
+    }
+}

--- a/src/main/java/com/BANnerIt/server/api/s3/service/S3Service.java
+++ b/src/main/java/com/BANnerIt/server/api/s3/service/S3Service.java
@@ -1,6 +1,7 @@
 package com.BANnerIt.server.api.s3.service;
 
 import com.BANnerIt.server.api.s3.domain.Image;
+import com.BANnerIt.server.api.s3.dto.PresignedUrlDto;
 import com.BANnerIt.server.api.s3.dto.PresignedUrlRequest;
 import com.BANnerIt.server.api.s3.dto.PresignedUrlResponse;
 import com.BANnerIt.server.api.s3.repository.ImageRepository;
@@ -26,18 +27,12 @@ public class S3Service {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public List<PresignedUrlResponse> generatePresignedUrls(PresignedUrlRequest request, String folder) {
-        List<PresignedUrlResponse> responseList = new ArrayList<>();
+    public PresignedUrlResponse generatePresignedUrls(PresignedUrlRequest request, String folder) {
+        List<PresignedUrlDto> urls = new ArrayList<>();
 
         for (String file : request.files()) {
             String uuid = UUID.randomUUID().toString();
             String key = folder + "/" + uuid + "." + file;
-
-            Image image = Image.builder()
-                    .imageKey(key)
-                    .build();
-
-            imageRepository.save(image);
 
             Date expiration = Date.from(Instant.now().plusSeconds(60 * 5)); // 5분 유효
 
@@ -47,9 +42,9 @@ public class S3Service {
 
             URL url = amazonS3.generatePresignedUrl(s3UrlRequest);
 
-            responseList.add(new PresignedUrlResponse(key, url.toString()));
+            urls.add(new PresignedUrlDto(key, url.toString()));
         }
 
-        return responseList;
+        return new PresignedUrlResponse(urls);
     }
 }

--- a/src/main/java/com/BANnerIt/server/global/config/S3Config.java
+++ b/src/main/java/com/BANnerIt/server/global/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.BANnerIt.server.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(Regions.fromName(region))
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .build();
+    }
+}


### PR DESCRIPTION
## ✅ Resolve
- #18 

## 🤷 구현 기능
- spring boot에 S3 의존성 주입
- properties파일 설정 추가
- Presigned URL 생성 기능 생성

## 🔨 구현 상태
**PreSigned URL 생성**
- 클라이언트가 이미지 목록 서버로 전송하면 Presigned URL을 발급한다.
- key : S3 안에서 파일이 ​저장될 경로와 이름​
- Presigned URL : 제한된 시간 동안​ 파일을 업로드할 수 있는 임시 링크
```plaintext
[Client] -- files --> createPresignedUrls()
    └── key와 Presigned URL 생성
```


## 🔗 참고링크
