### PR TITLE
chore: rds 설정을 위해서 build.gradle수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,11 +32,12 @@ dependencies {
 
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'io.jsonwebtoken:jjwt:0.12.6'
-	implementation 'mysql:mysql-connector-java:8.0.33'
 	implementation 'com.google.api-client:google-api-client:1.34.1'
 	implementation 'com.google.http-client:google-http-client-gson:1.41.0'
 	implementation 'com.google.http-client:google-http-client-jackson2:1.40.1'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'mysql:mysql-connector-java:8.0.33'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/test/java/com/BANnerIt/server/userTest/MemberControllerTest.java
+++ b/src/test/java/com/BANnerIt/server/userTest/MemberControllerTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 


### PR DESCRIPTION
## ✅ Resolve
- #

## 🤷 구현 기능
- rds 연결

## 🔨 구현 상태
- mysql rds 설정을 하기위해서 ` build.gradle`에 의존성 추가 
- submodule application.properties 수정 


## 🔗 참고링크
[Amazon RDS DB 인스턴스 생성 및 연결하기](https://velog.io/@banjjoknim/AWS-RDS-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0)

