### PR TITLE
fix: 회원 정보 수정시 body로 null이 갔을 경우 에러 발생 해결

### DIFF
--- a/src/main/java/com/BANnerIt/server/api/user/service/MemberService.java
+++ b/src/main/java/com/BANnerIt/server/api/user/service/MemberService.java
@@ -33,20 +33,20 @@ public class MemberService {
     }
 
     public boolean updateUser(Long userId, MemberUpdateRequest request) {
-        if (request.name() == null && request.userProfile() == null) {
-            throw new CustomException(ErrorCode.INVALID_REQUEST);
-        }
-
         final Member member = memberRepository.findById(userId).orElse(null);
 
         if (member == null) {
             return false;
         }
 
-        member.updateUser(request);
-        memberRepository.saveAndFlush(member);
+        if (request.name() != null || request.userProfile() != null) {
+            member.updateUser(request);
+            memberRepository.saveAndFlush(member);
+        }
+
         return true;
     }
+
 
     public boolean deleteMember(String token) {
         final Long userId = jwtTokenUtil.extractUserId(token);


### PR DESCRIPTION
## ✅ Resolve
- #

## 🤷 구현 기능
- body에 { } (변경사항없음) 이여도 에러가 발생하지 않고 유지하도록 수정

## 🔨 구현 상태
- 


## 🔗 참고링크
