### PR TITLE
fix: 회원정보 삭제시 reports의 created_by = null 설정

### DIFF
--- a/src/main/java/com/BANnerIt/server/api/banner/service/ReportService.java
+++ b/src/main/java/com/BANnerIt/server/api/banner/service/ReportService.java
@@ -120,10 +120,9 @@ public class ReportService {
                 .collect(Collectors.toList());
         List<String> images = s3Service.generateGetPresignedUrls(urls);
 
-        // 삭제된 회원의 reports getCreatedBy = 0으로설정
         Long createdById = Optional.ofNullable(r.getCreatedBy())
                 .map(Member::getUserId)
-                .orElse(0L);
+                .orElse(null);
 
         return new ReportLogDto(r.getReportId(), r.getCreatedAt(),
                 r.getStatus(), createdById, images, location, r.getContent(), banners);


### PR DESCRIPTION
## ✅ Resolve
- #

## 🤷 구현 기능


## 🔨 구현 상태
- 


## 🔗 참고링크
